### PR TITLE
Replace Colorize with Rainbow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Your changes/patches go here.
 
+- [CHORE: Remove GPL licensed dependency Colorize and replace it with Rainbow]
+
 # v1.3.0 / 2023-06-16 [(commits)](https://github.com/fastruby/next_rails/compare/v1.2.4...v1.3.0)
 
 - [FEATURE: Add NextRails.next? for application usage (e.g. Rails shims)](https://github.com/fastruby/next_rails/pull/97)

--- a/exe/deprecations
+++ b/exe/deprecations
@@ -1,8 +1,10 @@
 #!/usr/bin/env ruby
 require "json"
-require "colorize"
+require "rainbow/refinement"
 require "optparse"
 require "set"
+
+using Rainbow
 
 def run_tests(deprecation_warnings, opts = {})
   tracker_mode = opts[:tracker_mode]

--- a/lib/deprecation_tracker.rb
+++ b/lib/deprecation_tracker.rb
@@ -1,5 +1,7 @@
-require "colorize"
+require "rainbow/refinement"
 require "json"
+
+using Rainbow
 
 # A shitlist for deprecation warnings during test runs. It has two modes: "save" and "compare"
 #

--- a/lib/next_rails/bundle_report.rb
+++ b/lib/next_rails/bundle_report.rb
@@ -1,8 +1,10 @@
-require "colorize"
+require "rainbow/refinement"
 require "cgi"
 require "erb"
 require "json"
 require "net/http"
+
+using Rainbow
 
 module NextRails
   module BundleReport

--- a/next_rails.gemspec
+++ b/next_rails.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "colorize", ">= 0.8.1"
+  spec.add_dependency "rainbow", ">= 3"
   spec.add_development_dependency "bundler", ">= 1.16", "< 3.0"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/next_rails.gemspec
+++ b/next_rails.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "rainbow", ">= 3"
+  spec.add_dependency "rainbow", ">= 2"
   spec.add_development_dependency "bundler", ">= 1.16", "< 3.0"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", "~> 3.0"

--- a/spec/bundle_report_spec.rb
+++ b/spec/bundle_report_spec.rb
@@ -5,6 +5,8 @@ require 'tempfile'
 require_relative 'spec_helper'
 require_relative '../lib/next_rails/bundle_report'
 
+using Rainbow
+
 RSpec.describe NextRails::BundleReport do
   describe '.outdated' do
     let(:mock_version) { Struct.new(:version, :age) }


### PR DESCRIPTION
## Description

[Colorize](https://rubygems.org/gems/colorize) uses the GNU GPL 2.0 license. Replace it with MIT-licensed [Rainbow](https://rubygems.org/gems/rainbow)

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?
<!--- Include any relevant details about your testing environment and the steps you followed -->
<!--- For example: I am using [Safari|Firefox|Chrome] then I visit [the users path] -->

## Screenshots:
<!-- Add screenshots (applicable to any UI changes) -->

**I will abide by the [code of conduct](https://github.com/fastruby/next_rails/blob/main/CODE_OF_CONDUCT.md)**
